### PR TITLE
Do not break block operation when a user operation fails

### DIFF
--- a/SkillsWorkflow.Services.ADBlocker/App.config
+++ b/SkillsWorkflow.Services.ADBlocker/App.config
@@ -1,12 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <configuration>
-  <system.diagnostics>
-    <trace autoflush="true">
-      <listeners>
-        <add name="myListener" type="System.Diagnostics.TextWriterTraceListener, System, Version=1.0.3300.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" initializeData="ADBlocker.log" traceOutputOptions="DateTime"/>
-      </listeners>
-    </trace>
-  </system.diagnostics>
   <appSettings>
     <add key="AD:Domain" value="AD Domain"/>
     <add key="AD:User" value="AD Blocker UserName"/>

--- a/SkillsWorkflow.Services.ADBlocker/Models/User.cs
+++ b/SkillsWorkflow.Services.ADBlocker/Models/User.cs
@@ -13,5 +13,7 @@ namespace SkillsWorkflow.Services.ADBlocker.Models
     {
         public Guid Oid { get; set; }
         public DateTime? AccountExpirationDate { get; set; }
+        public bool Success { get; set; }
+        public string Message { get; set; }
     }
 }

--- a/SkillsWorkflow.Services.ADBlocker/Properties/AssemblyInfo.cs
+++ b/SkillsWorkflow.Services.ADBlocker/Properties/AssemblyInfo.cs
@@ -34,3 +34,4 @@ using System.Runtime.InteropServices;
 // [assembly: AssemblyVersion("1.0.*")]
 [assembly: AssemblyVersion("1.0.0.0")]
 [assembly: AssemblyFileVersion("1.0.0.0")]
+[assembly: log4net.Config.XmlConfigurator(ConfigFile = "log4net.config")]

--- a/SkillsWorkflow.Services.ADBlocker/SkillsWorkflow.Services.ADBlocker.csproj
+++ b/SkillsWorkflow.Services.ADBlocker/SkillsWorkflow.Services.ADBlocker.csproj
@@ -38,6 +38,9 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
+    <Reference Include="log4net, Version=2.0.8.0, Culture=neutral, PublicKeyToken=669e0ddf0bb1aa2a, processorArchitecture=MSIL">
+      <HintPath>..\packages\log4net.2.0.8\lib\net45-full\log4net.dll</HintPath>
+    </Reference>
     <Reference Include="Mindscape.Raygun4Net, Version=5.3.1.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\packages\Mindscape.Raygun4Net.5.4.0\lib\net40\Mindscape.Raygun4Net.dll</HintPath>
       <Private>True</Private>
@@ -75,6 +78,9 @@
   <ItemGroup>
     <None Include="App.config">
       <SubType>Designer</SubType>
+    </None>
+    <None Include="log4net.config">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </None>
     <None Include="packages.config" />
   </ItemGroup>

--- a/SkillsWorkflow.Services.ADBlocker/log4net.config
+++ b/SkillsWorkflow.Services.ADBlocker/log4net.config
@@ -1,0 +1,34 @@
+﻿<log4net>
+  <root>
+    <level value="ALL" />
+    <appender-ref ref="console" />
+    <appender-ref ref="file" />
+  </root>
+  <appender name="console" type="log4net.Appender.ConsoleAppender">
+    <layout type="log4net.Layout.PatternLayout">
+      <conversionPattern value="%date %level %logger - %message%newline" />
+    </layout>
+  </appender>
+  <appender name="file" type="log4net.Appender.RollingFileAppender,log4net">
+    <lockingModel type="log4net.Appender.FileAppender+MinimalLock"/>
+    <param name="StaticLogFileName" value="true"/>
+    <file type="log4net.Util.PatternString" value="ADBlocker_%date{yyyyMM}.log" />
+    <appendToFile value="true" />
+    <rollingStyle value="Date" />
+    <datePattern value="yyyyMM" />
+    <maximumFileSize value="20MB" />
+    <maxSizeRollBackups value="3" />
+    <layout type="log4net.Layout.PatternLayout">
+      <footer value="&#13;&#10;" />
+      <conversionPattern value="%level %date{dd MMM yyyy HH:mm:ss,fff} %logger - %message%newline" />
+    </layout>
+    <filter type="log4net.Filter.LevelRangeFilter">
+      <levelMin value="INFO" />
+      <levelMax value="FATAL" />
+    </filter>
+    <filter type="log4net.Filter.DenyAllFilter" />
+    <filter type="log4net.Filter.LevelMatchFilter">
+      <levelToMatch value="DEBUG" />
+    </filter>
+  </appender>
+</log4net>

--- a/SkillsWorkflow.Services.ADBlocker/packages.config
+++ b/SkillsWorkflow.Services.ADBlocker/packages.config
@@ -1,5 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
+  <package id="log4net" version="2.0.8" targetFramework="net462" />
   <package id="Mindscape.Raygun4Net" version="5.4.0" targetFramework="net452" />
   <package id="Newtonsoft.Json" version="9.0.1" targetFramework="net452" />
 </packages>


### PR DESCRIPTION
- Added logging per month  - changed logging engine
- Changed blocking logic - when a user is not blocked due to a network or directory sync issue the operation will continuefor other users